### PR TITLE
x86: add support for marking a device memory region at boot

### DIFF
--- a/include/arch/x86/arch/kernel/boot.h
+++ b/include/arch/x86/arch/kernel/boot.h
@@ -39,7 +39,8 @@ bool_t init_sys_state(
     acpi_rsdp_t      *acpi_rsdp,
     seL4_X86_BootInfo_VBE *vbe,
     seL4_X86_BootInfo_mmap_t *mb_mmap,
-    seL4_X86_BootInfo_fb_t *fb_info
+    seL4_X86_BootInfo_fb_t *fb_info,
+    p_region_t    extra_device_p_reg
 );
 
 bool_t init_cpu(

--- a/include/arch/x86/arch/kernel/boot_sys.h
+++ b/include/arch/x86/arch/kernel/boot_sys.h
@@ -29,6 +29,7 @@ typedef struct boot_state {
     seL4_X86_BootInfo_VBE vbe_info; /* Potential VBE information from multiboot */
     seL4_X86_BootInfo_mmap_t mb_mmap_info; /* memory map information from multiboot */
     seL4_X86_BootInfo_fb_t fb_info; /* framebuffer information as set by bootloader */
+    p_region_t   extra_device_p_reg; /* extra region reserved as device memory */
 } boot_state_t;
 
 extern boot_state_t boot_state;

--- a/include/arch/x86/arch/kernel/multiboot2.h
+++ b/include/arch/x86/arch/kernel/multiboot2.h
@@ -42,6 +42,11 @@ typedef struct multiboot2_fb {
     uint8_t  type;
 } PACKED multiboot2_fb_t;
 
+typedef struct multiboot2_devmem {
+    uint64_t addr;
+    uint64_t size;
+} PACKED multiboot2_devmem_t;
+
 enum multiboot2_tags {
     MULTIBOOT2_TAG_END     = 0,
     MULTIBOOT2_TAG_CMDLINE = 1,
@@ -50,5 +55,6 @@ enum multiboot2_tags {
     MULTIBOOT2_TAG_FB      = 8,
     MULTIBOOT2_TAG_ACPI_1  = 14,
     MULTIBOOT2_TAG_ACPI_2  = 15,
+    MULTIBOOT2_TAG_DEVMEM  = 42,
 };
 

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -23,7 +23,7 @@
 
 #include <plat/machine/intel-vtd.h>
 
-#define MAX_RESERVED 1
+#define MAX_RESERVED 2
 BOOT_BSS static region_t reserved[MAX_RESERVED];
 
 /* functions exactly corresponding to abstract specification */
@@ -68,16 +68,25 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
 }
 
 BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
+                                          p_region_t extra_device_p_reg,
                                           v_region_t it_v_reg,
                                           mem_p_regs_t *mem_p_regs,
                                           word_t extra_bi_size_bits)
 {
+    int index = 0;
+
     // Extend the reserved region down to include the base of the kernel image.
     // KERNEL_ELF_PADDR_BASE is the lowest physical load address used
     // in the x86 linker script.
     ui_p_reg.start = KERNEL_ELF_PADDR_BASE;
-    reserved[0] = paddr_to_pptr_reg(ui_p_reg);
-    return init_freemem(mem_p_regs->count, mem_p_regs->list, MAX_RESERVED,
+    reserved[index++] = paddr_to_pptr_reg(ui_p_reg);
+
+    /* add the extra device region, if it is not empty */
+    if (extra_device_p_reg.start != extra_device_p_reg.end) {
+        reserved[index++] = paddr_to_pptr_reg(extra_device_p_reg);
+    }
+
+    return init_freemem(mem_p_regs->count, mem_p_regs->list, index,
                         reserved, it_v_reg, extra_bi_size_bits);
 }
 
@@ -95,7 +104,8 @@ BOOT_CODE bool_t init_sys_state(
     acpi_rsdp_t      *acpi_rsdp,
     seL4_X86_BootInfo_VBE *vbe,
     seL4_X86_BootInfo_mmap_t *mb_mmap,
-    seL4_X86_BootInfo_fb_t *fb_info
+    seL4_X86_BootInfo_fb_t *fb_info,
+    p_region_t    extra_device_p_reg
 )
 {
     cap_t         root_cnode_cap;
@@ -110,6 +120,7 @@ BOOT_CODE bool_t init_sys_state(
     uint32_t      tsc_freq;
     create_frames_of_region_ret_t create_frames_ret;
     create_frames_of_region_ret_t extra_bi_ret;
+    seL4_SlotPos first_untyped_slot;
 
     /* convert from physical addresses to kernel pptrs */
     region_t ui_reg             = paddr_to_pptr_reg(ui_info.p_reg);
@@ -152,7 +163,7 @@ BOOT_CODE bool_t init_sys_state(
     }
 #endif /* CONFIG_IOMMU */
 
-    if (!arch_init_freemem(ui_info.p_reg, it_v_reg, mem_p_regs, extra_bi_size_bits)) {
+    if (!arch_init_freemem(ui_info.p_reg, extra_device_p_reg, it_v_reg, mem_p_regs, extra_bi_size_bits)) {
         printf("ERROR: free memory management initialization failed\n");
         return false;
     }
@@ -328,8 +339,14 @@ BOOT_CODE bool_t init_sys_state(
     ndks_boot.bi_frame->numIOPTLevels = -1;
 #endif
 
+    /* add the optional region of extra device memory */
+    first_untyped_slot = ndks_boot.slot_pos_cur;
+    if (extra_device_p_reg.start != extra_device_p_reg.end) {
+	create_untypeds_for_region(root_cnode_cap, true, paddr_to_pptr_reg(extra_device_p_reg), first_untyped_slot);
+    }
+
     /* create all of the untypeds. Both devices and kernel window memory */
-    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_reg, ndks_boot.slot_pos_cur)) {
+    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_reg, first_untyped_slot)) {
         return false;
     }
 

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -186,7 +186,8 @@ static BOOT_CODE bool_t try_boot_sys_node(cpu_id_t cpu_id)
             &boot_state.acpi_rsdp,
             &boot_state.vbe_info,
             &boot_state.mb_mmap_info,
-            &boot_state.fb_info
+            &boot_state.fb_info,
+            boot_state.extra_device_p_reg
         )) {
         return false;
     }
@@ -629,6 +630,8 @@ static BOOT_CODE bool_t try_boot_sys_mbi2(
     boot_state.mem_p_regs.count = 0;
     boot_state.mb_mmap_info.mmap_length = 0;
     boot_state.vbe_info.vbeMode = -1;
+    boot_state.extra_device_p_reg.start = 0;
+    boot_state.extra_device_p_reg.end = 0;
 
     while (tag < tag_e && tag->type != MULTIBOOT2_TAG_END) {
         word_t const behind_tag = (word_t)tag + sizeof(*tag);
@@ -693,6 +696,11 @@ static BOOT_CODE bool_t try_boot_sys_mbi2(
             printf("Got framebuffer info in multiboot2. Current video mode is at physical address=%llx pitch=%u resolution=%ux%u@%u type=%u\n",
                    fb->addr, fb->pitch, fb->width, fb->height, fb->bpp, fb->type);
             boot_state.fb_info = *fb;
+        } else if (tag->type == MULTIBOOT2_TAG_DEVMEM) {
+            multiboot2_devmem_t const *devmem = (multiboot2_devmem_t const *)behind_tag;
+            printf("Got extra device memory region at 0x%llx size 0x%llx\n", devmem->addr, devmem->size);
+            boot_state.extra_device_p_reg.start = devmem->addr;
+            boot_state.extra_device_p_reg.end = devmem->addr + devmem->size;
         }
 
         tag = (multiboot2_tag_t const *)((word_t)tag + ROUND_UP(tag->size, 3));


### PR DESCRIPTION
Microkit needs to pass to the kernel the address and size of a region of memory to be marked as "device" memory (device untyped). This region is populated by the bootloader with the contents of the user-space tasks.

On ARM and RISC-V this data is passed by two registers. This commit enables a similar feature on x86. An new multiboot2 boot info tag is used to pass the base address and size of the additional region. A compliant multiboot boot loader is necessary to pass the additional tag, such as the loader from microkit/x86. Note that this change is transparent if the tag is not exposed by the loader.